### PR TITLE
Added Mac Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ x32/
 [Dd]ebug/
 [Rr]elease/
 .vs/
+
+# macos
+.DS_Store

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -1,5 +1,9 @@
 #include "draw.hpp"
+#ifdef __APPLE__
+#include <stdlib.h>
+#else
 #include <malloc.h>
+#endif
 #include <stdio.h>
 #include <string.h>
 

--- a/src/libs/vkh/vkh.c
+++ b/src/libs/vkh/vkh.c
@@ -1,7 +1,11 @@
 #include "vkh.h"
 
 #include <stdio.h>
+#ifdef __APPLE__
+#include <stdlib.h>
+#else
 #include <malloc.h>
+#endif
 #include <string.h>
 
 //----------------------------------------------------------------------------//

--- a/src/libs/vkh/vkh.c
+++ b/src/libs/vkh/vkh.c
@@ -1153,6 +1153,10 @@ static vkh_bool_t _vkh_create_vk_instance(VKHinstance* inst, const char* name)
     requiredExtensionCount++;
 #endif
 
+    #if VKH_VALIDATION_LAYERS
+    requiredExtensionCount++;
+    #endif
+
     char** requiredExtensions = (char**)malloc(requiredExtensionCount * sizeof(char*));
     memcpy(requiredExtensions, requiredGlfwExtensions, requiredExtensionCount * sizeof(char*));
 
@@ -1160,6 +1164,11 @@ static vkh_bool_t _vkh_create_vk_instance(VKHinstance* inst, const char* name)
     //---------------
 #if __APPLE__
     requiredExtensions[requiredExtensionCount - 1] = VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME;
+    #if VKH_VALIDATION_LAYERS
+    requiredExtensions[requiredExtensionCount - 2] = VK_EXT_DEBUG_UTILS_EXTENSION_NAME;
+    #endif
+#else
+    requiredExtensions[requiredExtensionCount - 1] = VK_EXT_DEBUG_UTILS_EXTENSION_NAME;
 #endif
 
 	//check if glfw extensions are supported:

--- a/src/libs/vkh/vkh.c
+++ b/src/libs/vkh/vkh.c
@@ -61,8 +61,19 @@ static void _vkh_error_log(const char* message, const char* file, int32_t line);
 	const char* REQUIRED_LAYERS[REQUIRED_LAYER_COUNT] = {"VK_LAYER_KHRONOS_validation"};
 #endif
 
-#define REQUIRED_DEVICE_EXTENSION_COUNT 2
-const char* REQUIRED_DEVICE_EXTENSIONS[REQUIRED_DEVICE_EXTENSION_COUNT] = {VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_KHR_MAINTENANCE1_EXTENSION_NAME};
+#if __APPLE__
+    #define REQUIRED_DEVICE_EXTENSION_COUNT 3
+#else
+    #define REQUIRED_DEVICE_EXTENSION_COUNT 2
+#endif
+
+const char* REQUIRED_DEVICE_EXTENSIONS[REQUIRED_DEVICE_EXTENSION_COUNT] = {
+    VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+    VK_KHR_MAINTENANCE1_EXTENSION_NAME,
+#if __APPLE__
+    "VK_KHR_portability_subset"
+#endif
+};
 
 //----------------------------------------------------------------------------//
 
@@ -1150,7 +1161,7 @@ static vkh_bool_t _vkh_create_vk_instance(VKHinstance* inst, const char* name)
     //reserve space for portability extension
     //---------------
 #if __APPLE__
-    requiredExtensionCount++;
+    requiredExtensionCount += 2;
 #endif
 
     #if VKH_VALIDATION_LAYERS
@@ -1164,8 +1175,9 @@ static vkh_bool_t _vkh_create_vk_instance(VKHinstance* inst, const char* name)
     //---------------
 #if __APPLE__
     requiredExtensions[requiredExtensionCount - 1] = VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME;
+    requiredExtensions[requiredExtensionCount - 2] = "VK_KHR_get_physical_device_properties2";
     #if VKH_VALIDATION_LAYERS
-    requiredExtensions[requiredExtensionCount - 2] = VK_EXT_DEBUG_UTILS_EXTENSION_NAME;
+    requiredExtensions[requiredExtensionCount - 3] = VK_EXT_DEBUG_UTILS_EXTENSION_NAME;
     #endif
 #else
     requiredExtensions[requiredExtensionCount - 1] = VK_EXT_DEBUG_UTILS_EXTENSION_NAME;

--- a/src/libs/vkh/vkh.h
+++ b/src/libs/vkh/vkh.h
@@ -12,7 +12,7 @@ extern "C"
 
 #include "./quickdata.h"
 
-#define VKH_VALIDATION_LAYERS 1
+#define VKH_VALIDATION_LAYERS 0
 
 //----------------------------------------------------------------------------//
 

--- a/src/libs/vkh/vkh.h
+++ b/src/libs/vkh/vkh.h
@@ -12,7 +12,7 @@ extern "C"
 
 #include "./quickdata.h"
 
-#define VKH_VALIDATION_LAYERS 0
+#define VKH_VALIDATION_LAYERS 1
 
 //----------------------------------------------------------------------------//
 


### PR DESCRIPTION
I fixed a few issues that prevents compilation and running on MacOS. I'm running Sonoma (14.2.1) on a Macbook Air with an Intel chip. I don't think that should matter, but you never know.

Now, VkGalaxy can be compiled and ran without warnings or errors with `VKH_VALIDATION_LAYERS` enabled or not. Woo-hoo! I also tried to remain consistent with the style of your codebase to the best of my ability.

Take a look at the comments left on the commits. They may be helpful